### PR TITLE
Check reachability to peer controller when determine system state

### DIFF
--- a/forch/constants.py
+++ b/forch/constants.py
@@ -2,6 +2,7 @@
 
 STATE_ACTIVE = 'active'
 STATE_INACTIVE = 'inactive'
+STATE_SPLIT = 'split'
 STATE_HEALTHY = 'healthy'
 STATE_DAMAGED = 'damaged'
 STATE_UP = 'up'

--- a/forch/forchestrator.py
+++ b/forch/forchestrator.py
@@ -197,9 +197,19 @@ class Forchestrator:
             detail += '. Faucet disconnected.'
 
         vrrp_state = self._local_collector.get_vrrp_state()
+        peer_controller = self._get_peer_controller_info()[0]
+        cpn_nodes = self._cpn_collector.get_cpn_state().get('cpn_nodes', {})
+        peer_controller_state = cpn_nodes.get(peer_controller, {}).get('state')
+
+        if not peer_controller_state:
+            LOGGER.error('Cannot get peer controller state: %s', peer_controller)
+
         if not vrrp_state.get('is_master'):
             detail = 'This controller is inactive. Please view peer controller.'
             return constants.STATE_INACTIVE, detail
+        if not peer_controller_state == constants.STATE_HEALTHY:
+            detail = 'Lost reachability to peer controller.'
+            return constants.STATE_SPLIT, detail
         if has_error:
             return constants.STATE_BROKEN, detail
         if has_warning:


### PR DESCRIPTION
If this controller is master and peer controller is not reachable,
then the system is split as both controller will take master role.