### PR TITLE
Cleanup

### DIFF
--- a/forch/faucet_state_collector.py
+++ b/forch/faucet_state_collector.py
@@ -177,6 +177,11 @@ class FaucetStateCollector:
 
         return result
 
+    def cleanup(self):
+        self.learned_macs.clear()
+        for switch_data in self.switch_states.values():
+            switch_data.pop(LEARNED_MACS, None)
+
     def _fill_egress_state(self, dplane_state):
         """Return egress state obj"""
         with self.lock:

--- a/forch/faucet_state_collector.py
+++ b/forch/faucet_state_collector.py
@@ -178,6 +178,7 @@ class FaucetStateCollector:
         return result
 
     def cleanup(self):
+        """Clean up internal data"""
         self.learned_macs.clear()
         for switch_data in self.switch_states.values():
             switch_data.pop(LEARNED_MACS, None)

--- a/forch/forchestrator.py
+++ b/forch/forchestrator.py
@@ -32,7 +32,7 @@ class Forchestrator:
         self._server = None
         self._start_time = datetime.fromtimestamp(time.time()).isoformat()
         self._faucet_collector = FaucetStateCollector()
-        self._local_collector = LocalStateCollector(config.get('process'))
+        self._local_collector = LocalStateCollector(config.get('process'), self.cleanup)
         self._cpn_collector = CPNStateCollector()
 
     def initialize(self):
@@ -238,6 +238,9 @@ class Forchestrator:
     def _augment_state_reply(self, reply, path):
         url = self._extract_url_base(path)
         reply['system_state_url'] = url
+
+    def cleanup(self):
+        self._faucet_collector.cleanup()
 
     def get_switch_state(self, path, params):
         """Get the state of the switches"""

--- a/forch/forchestrator.py
+++ b/forch/forchestrator.py
@@ -127,12 +127,10 @@ class Forchestrator:
             return ('num_controllers_%s' % len(controllers), _DEFAULT_PORT)
         things = set(controllers.keys())
         things.remove(name)
-        peer = list(things)[0]
-        return peer
+        return list(things)[0]
 
     def _get_peer_controller_info(self):
-        peer = self._get_peer_controller_name()
-        return self._get_controller_info(peer)
+        return self._get_controller_info(self._get_peer_controller_name())
 
     def _get_peer_controller_url(self):
         return self._make_controller_url(self._get_peer_controller_info())

--- a/forch/forchestrator.py
+++ b/forch/forchestrator.py
@@ -244,6 +244,7 @@ class Forchestrator:
         reply['system_state_url'] = url
 
     def cleanup(self):
+        """Clean up relevant internal data in all collectors"""
         self._faucet_collector.cleanup()
 
     def get_switch_state(self, path, params):

--- a/forch/forchestrator.py
+++ b/forch/forchestrator.py
@@ -118,7 +118,7 @@ class Forchestrator:
     def _get_local_controller_url(self):
         return self._make_controller_url(self._get_controller_info(self._get_controller_name()))
 
-    def _get_peer_controller_info(self):
+    def _get_peer_controller_name(self):
         name = self._get_controller_name()
         controllers = self._config.get('site', {}).get('controllers', {})
         if name not in controllers:
@@ -128,6 +128,10 @@ class Forchestrator:
         things = set(controllers.keys())
         things.remove(name)
         peer = list(things)[0]
+        return peer
+
+    def _get_peer_controller_info(self):
+        peer = self._get_peer_controller_name()
         return self._get_controller_info(peer)
 
     def _get_peer_controller_url(self):
@@ -197,7 +201,7 @@ class Forchestrator:
             detail += '. Faucet disconnected.'
 
         vrrp_state = self._local_collector.get_vrrp_state()
-        peer_controller = self._get_peer_controller_info()[0]
+        peer_controller = self._get_peer_controller_name()
         cpn_nodes = self._cpn_collector.get_cpn_state().get('cpn_nodes', {})
         peer_controller_state = cpn_nodes.get(peer_controller, {}).get('state')
 


### PR DESCRIPTION
- Cleanup learned MACs when controller goes to inactive
- Use peer name to get peer controller state instead of peer hostname
