### PR TITLE
handle lag event

### DIFF
--- a/forch/faucet_state_collector.py
+++ b/forch/faucet_state_collector.py
@@ -535,6 +535,10 @@ class FaucetStateCollector:
         """process lag change event"""
         with self.lock:
             egress_state = self.topo_state.setdefault('egress', {})
+            old_egress_name = egress_state.get(EGRESS_DETAIL)
+            if old_egress_name and old_egress_name != name and not state:
+                return
+
             egress_state[EGRESS_LAST_UPDATE] = datetime.fromtimestamp(timestamp).isoformat()
             old_state = egress_state.get(EGRESS_STATE)
             new_state = constants.STATE_UP if state else constants.STATE_DOWN


### PR DESCRIPTION
If the inactive egress link goes down, Faucet will send a LAG down
event to Forch, which Forch evaluates as egress down. To avoid this,
only update the egress state when:
- No old state or
- new egress link is the same with old egress link
- or new state is up